### PR TITLE
moved blockcount into h2 handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,11 +96,11 @@ func main() {
 	}
 	defer client.Shutdown()
 
-	// Get the current block count.
-	blockCount, err := client.GetBlockCount()
-	if err != nil {
-		log.Fatal(err)
-	}
+	// // Get the current block count.
+	// blockCount, err := client.GetBlockCount()
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
 
 	// web stuff (collect target time)
 	fmt.Println("hello world")
@@ -112,6 +112,12 @@ func main() {
 	}
 
 	h2 := func(w http.ResponseWriter, r *http.Request) {
+
+		// Get the current block count.
+		blockCount, err := client.GetBlockCount()
+		if err != nil {
+			log.Fatal(err)
+		}
 		// log.Print("HTMX request recieved")
 		// log.Print(r.Header.Get("HX-Request"))
 		year, _ := strconv.Atoi(r.PostFormValue("year"))


### PR DESCRIPTION
The app had a bug where it would not return recent blockheights. The most recent blockheight that would be returned to the user was the blockheight from when the web server was last re-started. This fix moved the blockCount variable into the h2 handler, which is run when the submit button is clicked. This means the blockCount variable will be re-defined each time a user clicks submit instead of only once when the web server is started up. After some testing, this change allows blockheights up to the most recent blockheight to be returned to the user successfully.