### PR TITLE
Add caching for repeated requests and clean up code

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,71 +7,70 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/joho/godotenv"
 )
 
-func binarySearch(client *rpcclient.Client, blockCount int64, targetTime int64) int64 {
-	var leftBlockHeight, rightBlockHeight int64 = 0, blockCount
+var (
+	client     *rpcclient.Client
+	cacheMap   = make(map[int64]int64)
+	cacheMutex sync.RWMutex
+)
 
-	for leftBlockHeight <= rightBlockHeight {
+func getBlockTime(height int64) (int64, error) {
+    hash, err := client.GetBlockHash(height)
+    if err != nil {
+        return 0, fmt.Errorf("error getting block hash: %v", err)
+    }
+    block, err := client.GetBlockVerbose(hash)
+    if err != nil {
+        return 0, fmt.Errorf("error getting block details: %v", err)
+    }
+    return block.Time, nil
+}
 
-		// fmt.Println(rightBlockHeight)
-		// fmt.Println(blockCount)
-		// fmt.Println(targetTime)
+func binarySearch(blockCount int64, targetTime int64) int64 {
+    cacheMutex.RLock()
+    if cachedHeight, ok := cacheMap[targetTime]; ok {
+        cacheMutex.RUnlock()
+        return cachedHeight
+    }
+    cacheMutex.RUnlock()
 
-		midBlockHeight := (leftBlockHeight + rightBlockHeight) / 2
+    var leftBlockHeight, rightBlockHeight int64 = 0, blockCount
 
-		midBlockHash, err := client.GetBlockHash(midBlockHeight)
-		if err != nil {
-			log.Fatal(err)
-		}
+    for leftBlockHeight <= rightBlockHeight {
+        midBlockHeight := (leftBlockHeight + rightBlockHeight) / 2
 
-		midBlock, err := client.GetBlockVerbose(midBlockHash)
-		if err != nil {
-			log.Fatal(err)
-		}
-		// fmt.Println(midBlock.Time)
+        midBlockTime, err := getBlockTime(midBlockHeight)
+        if err != nil {
+            log.Printf("Error getting block time: %v", err)
+            return -1
+        }
 
-		// leftBlockHash, err := client.GetBlockHash(leftBlockHeight)
-		// 	if err != nil {
-		// 		log.Fatal(err)
-		// 	}
+        if midBlockTime == targetTime {
+            cacheMutex.Lock()
+            cacheMap[targetTime] = midBlockHeight
+            cacheMutex.Unlock()
+            return midBlockHeight
+        } else if midBlockTime < targetTime {
+            leftBlockHeight = midBlockHeight + 1
+        } else {
+            rightBlockHeight = midBlockHeight - 1
+        }
+    }
 
-		// leftBlock, err := client.GetBlockVerbose(leftBlockHash)
-		// 	if err != nil {
-		// 		log.Fatal(err)
-		// 	}
-
-		// rightBlockHash, err := client.GetBlockHash(rightBlockHeight)
-		// 	if err != nil {
-		// 		log.Fatal(err)
-		// 	}
-
-		// rightBlock, err := client.GetBlockVerbose(rightBlockHash)
-		// 	if err != nil {
-		// 		log.Fatal(err)
-		// 	}
-
-		midBlockTime := midBlock.Time
-		// leftBlockTime := leftBlock.Time
-		// rightBlockTime := rightBlock.Time
-
-		if midBlockTime == targetTime {
-			return midBlockHeight
-		} else if midBlockTime < targetTime {
-			leftBlockHeight = midBlockHeight + 1
-		} else {
-			rightBlockHeight = midBlockHeight - 1
-		}
-	}
-	return (leftBlockHeight)
+    result := leftBlockHeight
+    cacheMutex.Lock()
+    cacheMap[targetTime] = result
+    cacheMutex.Unlock()
+    return result
 }
 
 func main() {
-	// blockchain stuff
 	err := godotenv.Load(".env")
 	if err != nil {
 		log.Fatalf("Error loading .env file")
@@ -79,31 +78,23 @@ func main() {
 	username := os.Getenv("BTCUSER")
 	password := os.Getenv("PASSWORD")
 	host := os.Getenv("HOST")
-	// Connect to local bitcoin core RPC server using HTTP POST mode.
+
 	connCfg := &rpcclient.ConnConfig{
-		// Host:         "localhost:8332",
 		Host:         host,
 		User:         username,
 		Pass:         password,
-		HTTPPostMode: true, // Bitcoin core only supports HTTP POST mode
-		DisableTLS:   true, // Bitcoin core does not provide TLS by default
+		HTTPPostMode: true,
+		DisableTLS:   true,
 	}
-	// Notice the notification parameter is nil since notifications are
-	// not supported in HTTP POST mode.
-	client, err := rpcclient.New(connCfg, nil)
-	if err != nil {
-		log.Fatal(err)
+
+	var err2 error
+	client, err2 = rpcclient.New(connCfg, nil)
+	if err2 != nil {
+		log.Fatal(err2)
 	}
 	defer client.Shutdown()
 
-	// // Get the current block count.
-	// blockCount, err := client.GetBlockCount()
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-
-	// web stuff (collect target time)
-	fmt.Println("hello world")
+	fmt.Println("Server started")
 
 	h1 := func(w http.ResponseWriter, r *http.Request) {
 		tmpl := template.Must(template.ParseFiles("index.html"))
@@ -112,14 +103,13 @@ func main() {
 	}
 
 	h2 := func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
 
-		// Get the current block count.
 		blockCount, err := client.GetBlockCount()
 		if err != nil {
 			log.Fatal(err)
 		}
-		// log.Print("HTMX request recieved")
-		// log.Print(r.Header.Get("HX-Request"))
+
 		year, _ := strconv.Atoi(r.PostFormValue("year"))
 		month, _ := strconv.Atoi(r.PostFormValue("month"))
 		day, _ := strconv.Atoi(r.PostFormValue("day"))
@@ -129,29 +119,22 @@ func main() {
 
 		location, err := time.LoadLocation("America/New_York")
 		if err != nil {
-			// Handle error, e.g., log it or return an error
 			fmt.Println("Error loading location:", err)
-			// return or handle the error as appropriate
 		}
 
 		givenDateTime := time.Date(year, time.Month(month), day, hour, minute, second, 0, location)
-		// // fmt.Printf("given date time: %d\n", givenDateTime)
-		// // fmt.Printf("given date time: %d\n", givenDateTime.UTC())
 		targetTime := givenDateTime.Unix()
-		// log.Print(targetTime)
-		// target := FormatInt(int64(targetTime), 10)
-		// // fmt.Println(year)
 
-		// fmt.Println("Finding block height...")
-		result := binarySearch(client, blockCount, targetTime)
-		// fmt.Println(result)
-		// fmt.Printf("The block height at this date and time was: %d\n", result)
-		// fmt.Printf("Type of myVar: %T\n", result)
+		result := binarySearch(blockCount, targetTime)
 		resultStr := strconv.FormatInt(result, 10)
+
+		duration := time.Since(start)
+		log.Printf("Time taken for request: %v", duration)
+
 		tmpl, _ := template.New("t").Parse(resultStr)
 		tmpl.Execute(w, nil)
-
 	}
+
 	http.HandleFunc("/", h1)
 	http.HandleFunc("/get-blockheight/", h2)
 	log.Fatal(http.ListenAndServe(":8000", nil))

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 
 // Cache TTL of 24hrs
 const cacheTTL = 24 * time.Hour
-const averageBlockTime = 600 // Average block time in seconds (10 minutes)
+const averageBlockTime = 600
 
 type cacheEntry struct {
 	height    int64
@@ -61,12 +61,12 @@ func init() {
 
 func clearCachePeriodically() {
 	for {
-		time.Sleep(10 * time.Minute) // Run the cleanup every 10 minutes
+		time.Sleep(10 * time.Minute)
 
 		cacheMutex.Lock()
 		for targetTime, entry := range cacheMap {
 			if time.Since(entry.timestamp) > cacheTTL {
-				delete(cacheMap, targetTime) // Delete expired entries
+				delete(cacheMap, targetTime)
 			}
 		}
 		cacheMutex.Unlock()

--- a/main.go
+++ b/main.go
@@ -21,53 +21,53 @@ var (
 )
 
 func getBlockTime(height int64) (int64, error) {
-    hash, err := client.GetBlockHash(height)
-    if err != nil {
-        return 0, fmt.Errorf("error getting block hash: %v", err)
-    }
-    block, err := client.GetBlockVerbose(hash)
-    if err != nil {
-        return 0, fmt.Errorf("error getting block details: %v", err)
-    }
-    return block.Time, nil
+	hash, err := client.GetBlockHash(height)
+	if err != nil {
+		return 0, fmt.Errorf("error getting block hash: %v", err)
+	}
+	block, err := client.GetBlockVerbose(hash)
+	if err != nil {
+		return 0, fmt.Errorf("error getting block details: %v", err)
+	}
+	return block.Time, nil
 }
 
 func binarySearch(blockCount int64, targetTime int64) int64 {
-    cacheMutex.RLock()
-    if cachedHeight, ok := cacheMap[targetTime]; ok {
-        cacheMutex.RUnlock()
-        return cachedHeight
-    }
-    cacheMutex.RUnlock()
+	cacheMutex.RLock()
+	if cachedHeight, ok := cacheMap[targetTime]; ok {
+		cacheMutex.RUnlock()
+		return cachedHeight
+	}
+	cacheMutex.RUnlock()
 
-    var leftBlockHeight, rightBlockHeight int64 = 0, blockCount
+	var leftBlockHeight, rightBlockHeight int64 = 0, blockCount
 
-    for leftBlockHeight <= rightBlockHeight {
-        midBlockHeight := (leftBlockHeight + rightBlockHeight) / 2
+	for leftBlockHeight <= rightBlockHeight {
+		midBlockHeight := (leftBlockHeight + rightBlockHeight) / 2
 
-        midBlockTime, err := getBlockTime(midBlockHeight)
-        if err != nil {
-            log.Printf("Error getting block time: %v", err)
-            return -1
-        }
+		midBlockTime, err := getBlockTime(midBlockHeight)
+		if err != nil {
+			log.Printf("Error getting block time: %v", err)
+			return -1
+		}
 
-        if midBlockTime == targetTime {
-            cacheMutex.Lock()
-            cacheMap[targetTime] = midBlockHeight
-            cacheMutex.Unlock()
-            return midBlockHeight
-        } else if midBlockTime < targetTime {
-            leftBlockHeight = midBlockHeight + 1
-        } else {
-            rightBlockHeight = midBlockHeight - 1
-        }
-    }
+		if midBlockTime == targetTime {
+			cacheMutex.Lock()
+			cacheMap[targetTime] = midBlockHeight
+			cacheMutex.Unlock()
+			return midBlockHeight
+		} else if midBlockTime < targetTime {
+			leftBlockHeight = midBlockHeight + 1
+		} else {
+			rightBlockHeight = midBlockHeight - 1
+		}
+	}
 
-    result := leftBlockHeight
-    cacheMutex.Lock()
-    cacheMap[targetTime] = result
-    cacheMutex.Unlock()
-    return result
+	result := leftBlockHeight
+	cacheMutex.Lock()
+	cacheMap[targetTime] = result
+	cacheMutex.Unlock()
+	return result
 }
 
 func main() {


### PR DESCRIPTION
Made a few changes:

- Added caching for repeated requests.
- Cleaned up code a little
- getBlockTime is it's own function now
- RPC connection and env variables are only loaded once now so things are a bit faster.

Please test before merging!

Here's some bench marks for repeated requests and first time request.

<img width="545" alt="Screenshot 2024-09-18 at 7 44 24 PM" src="https://github.com/user-attachments/assets/db283183-14d0-4c4b-a9fa-41d6aa75592f">
